### PR TITLE
Default for new players

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Perma Time
 Makes it possible to permanently have day/night without changing the game time.  
 Type `/ptime` to either enable permanent daylight, permanent night or disable permanent time.
 
+You can use the setting 'ptime.default_newplayers' to set the behavior for new joining players 
+(default: ptime disabled).
+
 
 Optional Dependencies
 --------------

--- a/init.lua
+++ b/init.lua
@@ -6,18 +6,18 @@ minetest.register_privilege("daylight", {
 local function ptime(name)
 	local player = minetest.get_player_by_name(name)
     local pmeta = player:get_meta()
-	if not pmeta:get("ptime") then
-		pmeta:set_string("ptime", "day")
-		player:override_day_night_ratio(1)
-		minetest.chat_send_player(name, "-!- Perma Day has been enabled")
-    elseif pmeta:get("ptime") == "day" then
+    if pmeta:get("ptime") == "day" then
 		pmeta:set_string("ptime", "night")
 		player:override_day_night_ratio(.1)
 		minetest.chat_send_player(name, "-!- Perma Night has been enabled")
     elseif pmeta:get("ptime") == "night" then
-		pmeta:set_string("ptime", nil)
+		pmeta:set_string("ptime", "disabled")
 		player:override_day_night_ratio(nil)
 		minetest.chat_send_player(name, "-!- Perma Time has been disabled")
+    else
+        pmeta:set_string("ptime", "day")
+		player:override_day_night_ratio(1)
+		minetest.chat_send_player(name, "-!- Perma Day has been enabled")
     end
 end
 
@@ -37,7 +37,15 @@ minetest.register_chatcommand("ptime", {
 minetest.register_on_joinplayer(function(player)
 	local pname = player:get_player_name()
     local pmeta = player:get_meta()
-	if pmeta:get_string("ptime") == "day" then
+
+    if pmeta:get_string("ptime") == "" then
+        local default_int=tonumber(minetest.settings:get("ptime.default_newplayers")) or 0
+        if default_int==1 then pmeta:set_string("ptime","day")
+        elseif default_int==2 then pmeta:set_string("ptime","night")
+        else pmeta:set_string("ptime","disabled") end
+    end
+
+    if pmeta:get_string("ptime") == "day" then
         player:override_day_night_ratio(1)
 	    minetest.chat_send_player(pname, "-!- Perma Day is enabled")
 	elseif pmeta:get_string("ptime") == "night" then

--- a/init.lua
+++ b/init.lua
@@ -6,18 +6,18 @@ minetest.register_privilege("daylight", {
 local function ptime(name)
 	local player = minetest.get_player_by_name(name)
     local pmeta = player:get_meta()
-    if pmeta:get("ptime") == "day" then
+	if not pmeta:get("ptime") then
+		pmeta:set_string("ptime", "day")
+		player:override_day_night_ratio(1)
+		minetest.chat_send_player(name, "-!- Perma Day has been enabled")
+    elseif pmeta:get("ptime") == "day" then
 		pmeta:set_string("ptime", "night")
 		player:override_day_night_ratio(.1)
 		minetest.chat_send_player(name, "-!- Perma Night has been enabled")
     elseif pmeta:get("ptime") == "night" then
-		pmeta:set_string("ptime", "disabled")
+		pmeta:set_string("ptime", nil)
 		player:override_day_night_ratio(nil)
 		minetest.chat_send_player(name, "-!- Perma Time has been disabled")
-    else
-        pmeta:set_string("ptime", "day")
-		player:override_day_night_ratio(1)
-		minetest.chat_send_player(name, "-!- Perma Day has been enabled")
     end
 end
 
@@ -34,18 +34,19 @@ minetest.register_chatcommand("ptime", {
     end
 })
 
+minetest.register_on_newplayer(function(player)
+    local pname = player:get_player_name()
+    local pmeta = player:get_meta()
+    local default_int=tonumber(minetest.settings:get("ptime.default_newplayers")) or 0
+    if default_int==1 then pmeta:set_string("ptime","day")
+    elseif default_int==2 then pmeta:set_string("ptime","night")
+    else pmeta:set_string("ptime",nil) end
+end)
+
 minetest.register_on_joinplayer(function(player)
 	local pname = player:get_player_name()
     local pmeta = player:get_meta()
-
-    if pmeta:get_string("ptime") == "" then
-        local default_int=tonumber(minetest.settings:get("ptime.default_newplayers")) or 0
-        if default_int==1 then pmeta:set_string("ptime","day")
-        elseif default_int==2 then pmeta:set_string("ptime","night")
-        else pmeta:set_string("ptime","disabled") end
-    end
-
-    if pmeta:get_string("ptime") == "day" then
+	if pmeta:get_string("ptime") == "day" then
         player:override_day_night_ratio(1)
 	    minetest.chat_send_player(pname, "-!- Perma Day is enabled")
 	elseif pmeta:get_string("ptime") == "night" then

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,3 @@
+# set the default value for ptime chosen for new joining players.
+# 0=ptime disabled, 1=permanent day, 2=permanent night, anything else=ptime disabled
+ptime.default_newplayers (ptime default for new players) int 0


### PR DESCRIPTION
This adds a configurable setting to set a ptime value to be auto-set for new players at join time.
If this configurable value is set to '1',  at join time new players will have ptime set to 'day'
If '2', -> 'night'
Any other value, it will be set to 'disabled'. The default value is '0', so if players join before the default is changed, their ptime will be set to 'disabled'.

In order for the players' preference to be remembered when they log out in case they manually disabled ptime, even when they set it to disabled, this pr changes the value-cycling to day->night->disabled instead of day->night->nil, when toggling with /ptime.

This means that by default, it works exactly the same as before this PR, and typing '/ptime' has the same effect as before. Only now, you can set a ptime for new players that haven't joined after* this PR's change.