### PR TITLE
add setting for new players

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Makes it possible to permanently have day/night without changing the game time.
 Type `/ptime` to either enable permanent daylight, permanent night or disable permanent time.
 
 
+Settings
+--------
+ptime.default in minetest.conf can be set to day/night for new players. 
+The default is disabled
+
+
 Optional Dependencies
 --------------
 unified_inventory

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,1 @@
+ptime.default (default for new players [day/night]) string


### PR DESCRIPTION
superseeds https://github.com/xenonca/ptime/pull/6 
also adds some minor refactoring 
notes: the ptime(name) function perhaps should be rewritten in the future to avoid hard coding so much. perhaps it could be worked out that all settings are stored in data table